### PR TITLE
point conversation sync components to us region

### DIFF
--- a/cc-raisely-components/components/cc-user-save/cc-user-save.js
+++ b/cc-raisely-components/components/cc-user-save/cc-user-save.js
@@ -46,9 +46,9 @@
 
 	const syncHost = {
 		production:
-			'https://asia-northeast1-climate-conversations-sync.cloudfunctions.net',
+			'https://us-central1-climate-conversations-sync.cloudfunctions.net',
 		staging:
-			'https://asia-northeast1-cc-website-staging.cloudfunctions.net',
+			'https://us-central1-cc-website-staging.cloudfunctions.net',
 		development: 'http://localhost:3500',
 	}[mode];
 


### PR DESCRIPTION
# Climate conversations Merge Checklist

#### Issue: point conversation sync components to us region

##### link to Trello board: https://trello.com/c/4Ry0xvL8/45-move-cloud-functions-for-conversation-sync-subfolder

Description of issue: - 

Proposed changes: updated url in synchost variable to point to us-central1
