### PR TITLE
volunteer statistics for team leaders is not displaying correctly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-	"editor.formatOnSave": false,
+	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-	"editor.formatOnSave": true,
+	"editor.formatOnSave": false,
 	"editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/cc-raisely-components/components/volunteer-stats/volunteer-stats.js
+++ b/cc-raisely-components/components/volunteer-stats/volunteer-stats.js
@@ -45,11 +45,9 @@
 				const { mock } = this.props.global.campaign;
 				if (mock) {
 					stats = this.mockResponse(teamMode);
-					console.log(stats)
 				} else {
 					const userUuid = await this.getUserUuids();
 					stats = await (teamMode ? this.loadTeam(userUuid) : this.loadFacil(userUuid));
-					console.log(stats)
 				}
 
 				const labelledStats = labels
@@ -91,11 +89,11 @@
 				campaignUuid,
 				userUuid
 			);
+
 			const stats = {
-				complete: conversations.filter(c => get(c, 'private.status' === 'complete')).length,
-				booked: conversations.filter(c => get(c, 'private.status' === 'booked')).length,
+				complete: conversations.filter(c => get(c, 'private.status') === 'complete').length,
+				booked: conversations.filter(c => get(c, 'private.status')  === 'booked').length,
 			};
-			console.log('team stats', stats)
 			return stats;
 		}
 


### PR DESCRIPTION
# Climate conversations Merge Checklist

#### Issue: bug in volunter-stats.js 

##### link to Trello board: https://trello.com/c/4Y1UhG90/4-ftl-people-reached-statistic-seems-to-be-wrong

Description of issue:
The issue lies in:
```
const stats = {
complete: conversations.filter(c => get(c, 'private.status' ==='complete')).length,
booked: conversations.filter(c => get(c, 'private.status' === 'booked')).length
}
```
`conversations.filter(c => get(c, 'private.status' ==='complete')).length` returns undefined because the function is used incorrectly.

Proposed changes:
Fixed function arguments `conversations.filter(c => get(c, 'private.status')  ==='complete' ).length`

Additional notes:
Volunteer stats for facilis are fine. I may have recorded the issue wrongly as I was still quite new to the system at that time.