### PR TITLE
dynamically change document title to event name

### DIFF
--- a/cc-raisely-components/components/event-rsvp/event-rsvp.js
+++ b/cc-raisely-components/components/event-rsvp/event-rsvp.js
@@ -15,6 +15,7 @@
 
 		componentDidMount() {
 			this.buildSteps();
+			document.title = this.props.event.name;
 		}
 
 		componentDidUpdate() {


### PR DESCRIPTION
# Climate conversations Merge Checklist

#### Issue: Tab title for Events

##### link to Trello board: https://trello.com/c/OiXGpLiL/49-tab-title-for-events

Description of issue:
Tab titles for events on the website are always "Loading..." 
This creates confusion as it may appear to users that the page is still loading when it is already done loading. 

Proposed changes:
dynamically change the document title to the event name
